### PR TITLE
Add simple ECS subsystem and tests

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -1,10 +1,11 @@
 #include "Engine.h"
 #include "Platform.h" // Interface; implementation provided by platform module.
+#include "SimpleECS.h"
 
 #include <iostream>
 
 Engine::Engine(std::unique_ptr<Platform> platform)
-    : platform_(std::move(platform)) {}
+    : platform_(std::move(platform)), ecs_(std::make_unique<SimpleECS>()) {}
 
 Engine::~Engine() = default;
 
@@ -22,7 +23,7 @@ void Engine::Run() {
     // rendering, and subsystem coordination.
     while (running_) {
         platform_->PollEvents();
-        // Placeholder for game and engine updates.
+        ecs_->Update(0.016); // Fixed timestep placeholder.
         running_ = false; // Run one iteration for demonstration purposes.
     }
 }
@@ -36,4 +37,8 @@ void Engine::Shutdown() {
 
 EventBus& Engine::GetEventBus() {
     return event_bus_;
+}
+
+IECS& Engine::GetECS() {
+    return *ecs_;
 }

--- a/engine/Engine.h
+++ b/engine/Engine.h
@@ -6,6 +6,7 @@
 class Platform;
 
 #include "EventBus.h"
+#include "IECS.h"
 
 //------------------------------------------------------------------------------
 // Engine
@@ -33,8 +34,12 @@ public:
     // Access the global event bus for decoupled communication.
     EventBus& GetEventBus();
 
+    // Access the entity-component-system instance.
+    IECS& GetECS();
+
 private:
     std::unique_ptr<Platform> platform_;
     bool running_ = false;
     EventBus event_bus_;
+    std::unique_ptr<IECS> ecs_;
 };

--- a/engine/SimpleECS.h
+++ b/engine/SimpleECS.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "IECS.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+
+//------------------------------------------------------------------------------
+// SimpleECS
+//------------------------------------------------------------------------------
+// A lightweight Entity-Component-System implementation intended to demonstrate
+// how the engine can evolve. Entities are represented by integer IDs and
+// components are stored in type-indexed associative containers. Systems can be
+// registered as callbacks that are invoked every update.
+class SimpleECS : public IECS {
+public:
+    using Entity = std::uint32_t;
+    using SystemFunc = std::function<void(double)>;
+
+    SimpleECS();
+    ~SimpleECS() override = default;
+
+    // Creates a new entity identifier.
+    Entity CreateEntity();
+
+    // Destroys an entity and removes all associated components.
+    void DestroyEntity(Entity entity);
+
+    // Adds a component of type T to the entity. Returns reference to the new
+    // component.
+    template <typename T, typename... Args>
+    T& AddComponent(Entity entity, Args&&... args) {
+        auto& store = components_[std::type_index(typeid(T))];
+        auto comp = std::make_shared<T>(std::forward<Args>(args)...);
+        store[entity] = comp;
+        return *comp;
+    }
+
+    // Retrieves a component of type T for the given entity. Returns nullptr if
+    // the component is absent.
+    template <typename T>
+    T* GetComponent(Entity entity) {
+        auto type = std::type_index(typeid(T));
+        auto it = components_.find(type);
+        if (it == components_.end()) {
+            return nullptr;
+        }
+        auto it2 = it->second.find(entity);
+        if (it2 == it->second.end()) {
+            return nullptr;
+        }
+        return static_cast<T*>(it2->second.get());
+    }
+
+    // Removes a component of type T from the entity if present.
+    template <typename T>
+    void RemoveComponent(Entity entity) {
+        auto type = std::type_index(typeid(T));
+        auto it = components_.find(type);
+        if (it != components_.end()) {
+            it->second.erase(entity);
+        }
+    }
+
+    // Registers a system callback that will be invoked during Update().
+    void RegisterSystem(SystemFunc system);
+
+    // Invokes all registered systems with the provided timestep.
+    void Update(double delta_time) override;
+
+private:
+    Entity next_entity_;
+    std::unordered_map<std::type_index, std::unordered_map<Entity, std::shared_ptr<void>>> components_;
+    std::vector<SystemFunc> systems_;
+};
+
+
+inline SimpleECS::SimpleECS() : next_entity_(1) {}
+
+inline SimpleECS::Entity SimpleECS::CreateEntity() { return next_entity_++; }
+
+inline void SimpleECS::DestroyEntity(Entity entity) {
+    for (auto& [type, store] : components_) {
+        store.erase(entity);
+    }
+}
+
+inline void SimpleECS::RegisterSystem(SystemFunc system) {
+    systems_.push_back(std::move(system));
+}
+
+inline void SimpleECS::Update(double delta_time) {
+    for (auto& system : systems_) {
+        system(delta_time);
+    }
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(titan_tests
     EngineTests.cpp
+    ECSTests.cpp
     ${PROJECT_SOURCE_DIR}/third_party/catch_amalgamated.cpp
 )
 

--- a/tests/ECSTests.cpp
+++ b/tests/ECSTests.cpp
@@ -1,0 +1,31 @@
+#include <catch_amalgamated.hpp>
+#include "SimpleECS.h"
+
+struct Position {
+    int x;
+    int y;
+    Position() = default;
+    Position(int x_, int y_) : x(x_), y(y_) {}
+};
+
+TEST_CASE("SimpleECS stores and retrieves components") {
+    SimpleECS ecs;
+    auto e = ecs.CreateEntity();
+    ecs.AddComponent<Position>(e, 1, 2);
+    auto* p = ecs.GetComponent<Position>(e);
+    REQUIRE(p);
+    REQUIRE(p->x == 1);
+    REQUIRE(p->y == 2);
+    ecs.RemoveComponent<Position>(e);
+    REQUIRE(ecs.GetComponent<Position>(e) == nullptr);
+}
+
+TEST_CASE("SimpleECS updates registered systems") {
+    SimpleECS ecs;
+    double acc = 0.0;
+    ecs.RegisterSystem([&](double dt) { acc += dt; });
+    ecs.Update(0.5);
+    ecs.Update(0.5);
+    REQUIRE(acc == Catch::Approx(1.0));
+}
+


### PR DESCRIPTION
## Summary
- implement a lightweight entity-component-system with entity IDs, component storage, and system callbacks
- integrate ECS into the Engine and expose it via `GetECS`
- add unit tests covering component operations and system updates

## Testing
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_6891803a3de08320811b65d38daba468