### PR TITLE
Add simulation machine for fixed timestep updates

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(engine
     Engine.cpp
     EventBus.cpp
+    SimulationMachine.cpp
 )
 
 target_include_directories(engine

--- a/engine/SimulationMachine.cpp
+++ b/engine/SimulationMachine.cpp
@@ -1,0 +1,17 @@
+#include "SimulationMachine.h"
+
+SimulationMachine::SimulationMachine(double fixed_delta, UpdateFunc update)
+    : fixed_delta_(fixed_delta), update_(std::move(update)), lag_(0.0) {}
+
+void SimulationMachine::Advance(double frame_time) {
+    lag_ += frame_time;
+    while (lag_ >= fixed_delta_) {
+        update_(fixed_delta_);
+        lag_ -= fixed_delta_;
+    }
+}
+
+double SimulationMachine::GetLag() const {
+    return lag_;
+}
+

--- a/engine/SimulationMachine.h
+++ b/engine/SimulationMachine.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <functional>
+
+//------------------------------------------------------------------------------
+// SimulationMachine
+//------------------------------------------------------------------------------
+// Executes simulation steps at a fixed timestep. Accumulates variable frame
+// times and invokes the provided update callback as many times as necessary to
+// catch up.
+class SimulationMachine {
+public:
+    using UpdateFunc = std::function<void(double)>;
+
+    // Constructs the machine with a fixed timestep and update callback.
+    SimulationMachine(double fixed_delta, UpdateFunc update);
+
+    // Advances the simulation by the given frame time. The update callback is
+    // invoked zero or more times with the fixed timestep until the accumulated
+    // time is less than one step.
+    void Advance(double frame_time);
+
+    // Returns the remaining unprocessed time in the accumulator.
+    double GetLag() const;
+
+private:
+    double fixed_delta_;
+    UpdateFunc update_;
+    double lag_;
+};
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(titan_tests
     EngineTests.cpp
     ECSTests.cpp
+    SimulationMachineTests.cpp
     ${PROJECT_SOURCE_DIR}/third_party/catch_amalgamated.cpp
 )
 

--- a/tests/SimulationMachineTests.cpp
+++ b/tests/SimulationMachineTests.cpp
@@ -1,0 +1,18 @@
+#include <catch_amalgamated.hpp>
+#include "SimulationMachine.h"
+
+TEST_CASE("SimulationMachine processes fixed steps") {
+    int steps = 0;
+    double total = 0.0;
+    SimulationMachine sim(0.1, [&](double dt) {
+        steps++;
+        total += dt;
+    });
+
+    sim.Advance(0.35);
+
+    REQUIRE(steps == 3);
+    REQUIRE(total == Catch::Approx(0.3));
+    REQUIRE(sim.GetLag() == Catch::Approx(0.05));
+}
+


### PR DESCRIPTION
## Summary
- implement SimulationMachine that advances a simulation using a fixed timestep and accumulated lag
- hook SimulationMachine into engine library and unit tests
- verify stepping behavior with new test

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c38dab6f58832086d201cd353a7848